### PR TITLE
Keep properties from original package.json when reconfiguring

### DIFF
--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -11,12 +11,10 @@ function reconfigure(appPackage, config) {
 function reconfigurePackage(package) {
     var config = package.config;
     var description = package.packageDescription;
-    var reconfig = {};
-    reconfig.name = description.name;
-    reconfig.version = description.version;
+    var reconfig = Object.clone(description);
+
     reconfig.hash = package.hash;
-    reconfig.main = description.main;
-    reconfig.redirects = description.redirects;
+
     if (description.directories && description.directories.lib !== "lib") {
         reconfig.directories = reconfig.directories || {};
         reconfig.directories.lib = description.directories.lib;

--- a/spec/reconfigure-spec.js
+++ b/spec/reconfigure-spec.js
@@ -1,0 +1,77 @@
+/*global describe,before,it,expect,after */
+
+var reconfigure = require("../lib/reconfigure");
+
+describe("reconfigure", function() {
+    var appPackage;
+    beforeEach(function () {
+        appPackage = {
+            packages: {
+                "a": {
+                    buildLocation: "file:///build/a/",
+                    config: {
+                        mappings: {}
+                    },
+                    files: {
+                        "package.json": {}
+                    },
+                    packageDescription: {
+                        name: "a"
+                    }
+                }
+            }
+        };
+    });
+
+    it("keeps the name", function () {
+        reconfigure(appPackage);
+        expect(
+            JSON.parse(appPackage.packages["a"].files["package.json"].utf8).name
+        ).toBe("a");
+    });
+
+    it("sets production to true", function () {
+        reconfigure(appPackage);
+        expect(
+            JSON.parse(appPackage.packages["a"].files["package.json"].utf8).production
+        ).toBe(true);
+    });
+
+    it("sets useScriptInjection to true", function () {
+        reconfigure(appPackage);
+        expect(
+            JSON.parse(appPackage.packages["a"].files["package.json"].utf8).useScriptInjection
+        ).toBe(true);
+    });
+
+    it("rebases mappings", function () {
+        appPackage.packages["a"].config.mappings = {
+            "b": {
+                location: "file:///build/b/"
+            }
+        };
+        appPackage.packages["a"].packages = {
+            "file:///build/b/": {
+                config: {
+                    name: "bee"
+                },
+                hash: "xxx",
+                buildLocation: "file:///build/b/"
+            }
+        };
+        reconfigure(appPackage);
+        var reconfiguredMapping = JSON.parse(appPackage.packages["a"].files["package.json"].utf8).mappings.b;
+        expect(reconfiguredMapping.name).toEqual("bee");
+        expect(reconfiguredMapping.hash).toEqual("xxx");
+        expect(reconfiguredMapping.location).toEqual("../b/");
+    });
+
+    it("passes through properties it doesn't recognize", function () {
+        appPackage.packages["a"].packageDescription.unknownABC = "pass";
+        reconfigure(appPackage);
+        expect(
+            JSON.parse(appPackage.packages["a"].files["package.json"].utf8).unknownABC
+        ).toBe("pass");
+    });
+
+});


### PR DESCRIPTION
Previously we were wiping out properties that we didn't recognize,
which caused problems with Montage localization and would likely
cause more issues in the future.
