### PR TITLE
Don't show non-important warnings for other packages

### DIFF
--- a/lib/transform/css.js
+++ b/lib/transform/css.js
@@ -15,8 +15,10 @@ function rebaseCss(css, file, config) {
     try {
         ast = CSSO.parse(css);
     } catch (exception) {
-        config.out.warn("CSS parse error in " + file.path + ": " + exception.message);
-        return css;
+        if (file.package.isMainPackage()) {
+            config.out.warn("CSS parse error in " + file.path + ": " + exception.message);
+            return css;
+        }
     }
 
     var worklist = [ast];
@@ -33,7 +35,9 @@ function rebaseCss(css, file, config) {
                 // escaped by rebase
                 node[1] = value = ["raw"];
             } else {
-                config.out.warn("Unknown URI type in " + file.path + ": " + value);
+                if (file.package.isMainPackage()) {
+                    config.out.warn("Unknown URI type in " + file.path + ": " + value);
+                }
                 continue;
             }
 

--- a/lib/transform/html.js
+++ b/lib/transform/html.js
@@ -25,8 +25,10 @@ function transformHtml(file, config) {
             removeEmptyAttributes: true
         });
     } catch (exception) {
-        config.out.warn("Could not minify " + file.path);
-        config.out.warn(exception.message);
+        if (file.package.location === config.location) {
+            config.out.warn("Could not minify " + file.path);
+            config.out.warn(exception.message);
+        }
     }
 
     var definedContent = (

--- a/lib/transform/javascript.js
+++ b/lib/transform/javascript.js
@@ -19,14 +19,17 @@ function transformJavaScript(file, config) {
     var id = file.relativeLocation.replace(/\.js$/, "");
     var dependencies = MontageRequire.parseDependencies(file.utf8);
 
-    if (id.toLowerCase() !== id) {
-        config.out.warn("Module file name should be all lower-case " + relativeToWorkingLocation(file.location));
-    }
-    dependencies.forEach(function (dependency) {
-        if (dependency.toLowerCase() !== dependency) {
-            config.out.warn("Module identifier " + JSON.stringify(dependency) + " should be lower-case in " + relativeToWorkingLocation(file.location));
+    if (file.package.isMainPackage()) {
+        if (id.toLowerCase() !== id) {
+            config.out.warn("Module file name should be all lower-case " + relativeToWorkingLocation(file.location));
         }
-    });
+
+        dependencies.forEach(function (dependency) {
+            if (dependency.toLowerCase() !== dependency) {
+                config.out.warn("Module identifier " + JSON.stringify(dependency) + " should be lower-case in " + relativeToWorkingLocation(file.location));
+            }
+        });
+    }
 
     var definedContent = (
         "montageDefine(" +
@@ -57,14 +60,18 @@ function transformJavaScript(file, config) {
         try {
             file.utf8 = minifyJavaScript(file.utf8, file.path);
         } catch (exception) {
-            config.out.warn("JavaScript parse error in " + relativeToWorkingLocation(file.location) + ": " + exception.message);
+            if (file.package.isMainPackage()) {
+                config.out.warn("JavaScript parse error in " + relativeToWorkingLocation(file.location) + ": " + exception.message);
+            }
         }
 
         // minify defined .load.js
         try {
             definedFile.utf8 = minifyJavaScript(definedFile.utf8, definedFile.path);
         } catch (exception) {
-            config.out.warn("JavaScript parse error in " + definedFile.path + ": " + exception.message);
+            if (file.package.isMainPackage()) {
+                config.out.warn("JavaScript parse error in " + definedFile.path + ": " + exception.message);
+            }
         }
 
     }

--- a/lib/transform/json.js
+++ b/lib/transform/json.js
@@ -32,10 +32,10 @@ function transformJson(file, config) {
         try {
             file.utf8 = JSON.stringify(JSON.parse(file.utf8));
         } catch (exception) {
-            if (exception instanceof SyntaxError) {
-                config.out.warn("JSON parse error in " + relativeToWorkingLocation(file.location) + ": " + exception.message);
-            } else {
+            if (!(exception instanceof SyntaxError)) {
                 throw exception;
+            } else if (file.package.isMainPackage()) {
+                config.out.warn("JSON parse error in " + relativeToWorkingLocation(file.location) + ": " + exception.message);
             }
         }
 
@@ -43,7 +43,9 @@ function transformJson(file, config) {
         try {
             definedFile.utf8 = minifyJavaScript(definedFile.utf8, definedFile.path);
         } catch (exception) {
-            config.out.warn("JSON parse error in " + definedFile.path + ": " + exception.message);
+            if (file.package.isMainPackage()) {
+                config.out.warn("JSON parse error in " + definedFile.path + ": " + exception.message);
+            }
         }
     }
 }

--- a/spec/transform/css-spec.js
+++ b/spec/transform/css-spec.js
@@ -14,7 +14,10 @@ describe("transform/css", function () {
     var fileMock;
     beforeEach(function () {
         fileMock = {
-            path: "test.css"
+            path: "test.css",
+            package: {
+                isMainPackage: function () { return true; }
+            }
         };
     });
 
@@ -25,7 +28,7 @@ describe("transform/css", function () {
     });
 
     it("warns on invalid CSS", function () {
-        var input = "}";
+        var input = "\n}";
         var warnings = [];
         var config = {
             out: {
@@ -37,7 +40,7 @@ describe("transform/css", function () {
 
         var output = rebaseCss(input, fileMock, config);
         expect(output).toBe(input);
-        expect(warnings[0]).toBe("CSS parse error: test.css");
+        expect(warnings[0]).toBe("CSS parse error in test.css: Please check the validity of the CSS block starting from the line #2");
     });
 
     it("rebases single-quoted URIs", function () {


### PR DESCRIPTION
See gh-27.

Maybe parse errors shouldn't be ignored as they could be important to the user?
