### PR TITLE
Fix independent modules creating different bundles

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -173,11 +173,10 @@ function collectPreloadBundles(loader, bundler, config) {
                     error.message = "Can't collect the dependencies of " + JSON.stringify(id) + " in package " + loader.location + " because " + error.message;
                     throw error;
                 });
-            })
-            .then(function () {
-                var phase = collectBundle(loader, bundler, config);
-                phases.push(phase);
             });
+        }).then(function () {
+            var phase = collectBundle(loader, bundler, config);
+            phases.push(phase);
         });
     })
     .then(function () {

--- a/spec/bundle-spec.js
+++ b/spec/bundle-spec.js
@@ -1,6 +1,7 @@
 /*global describe,before,it,expect,after */
 var bundle = require("../lib/bundle");
 var MockFs = require("q-io/fs-mock");
+var Q = require("q");
 
 describe("Bundle", function() {
     var content, file, config;
@@ -46,6 +47,49 @@ describe("Bundle", function() {
         it("puts it in the files list", function () {
             var out = bundle.createBundle(content, file, config);
             expect(config.files["/name.html.js"]).toBe(out);
+        });
+    });
+
+    describe("collectPreloadBundles", function() {
+        it("should collect two modules that don't depend on each other into the same bundle", function(done) {
+            var bundler = {
+                packageDescription: {
+                    bundle: [["foo", "bar"]]
+                },
+                getPackage: function(location) {
+                    return {
+                        location: location
+                    };
+                }
+            };
+            var loader = {
+                deepLoad: function(id) {
+                    this.packages["app/"].modules[id] = {
+                        location: id,
+                        type: "javascript",
+                        bundled: false
+                    };
+                    return Q.resolve();
+                },
+                packageDescription: {},
+                packages: {
+                    "app/": {
+                        bundled: true,
+                        modules: {}
+                    }
+                }
+            };
+            var config = {
+                files: {
+                    "app/foo.load.js": {utf8: "app/foo.load.js"},
+                    "app/bar.load.js": {utf8: "app/bar.load.js"}
+                }
+            };
+
+            bundle.collectPreloadBundles(loader, bundler, config)
+            .then(function(bundle) {
+                expect(bundle).toEqual([[["app/foo.load.js", "app/bar.load.js"]]]);
+            }).then(done, done);
         });
     });
 });


### PR DESCRIPTION
When the bundle property was configured in a way that two independent modules should end up in the same bundle (e.g.: bundle: [["foo", "bar"]]) each module would still create its own bundle instead of being in the same.

The problem was that we were collecting the bundle at each moduleId deepLoad instead of each phase deepLoad, so a single bundle was only being generated for a single phase when the first moduleId of the phase depended on all other modules of the phase.

EDIT: not sure about the test though, there's probably a better way.
