### PR TITLE
Update dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "bluebird": "~3.0.5",
     "q-io": "~1.11.0",
     "url2": "~1.0.1",
-    "semver": "~1.1.4",
-    "uglify-js": "~2.2.5",
-    "optimist": "~0.5.0",
-    "csso": "~1.3.7",
-    "html-minifier": "~0.5.2",
+    "semver": "~5.0.3",
+    "uglify-js": "~2.5.0",
+    "optimist": "~0.6.1",
+    "csso": "~1.3.12",
+    "html-minifier": "~0.8.0",
     "minidom": "~1.0.0"
   },
   "devDependencies": {

--- a/spec/transform/css-spec.js
+++ b/spec/transform/css-spec.js
@@ -65,18 +65,6 @@ describe("transform/css", function () {
         //expect(warnings[1]).toBe("Cannot read property 'length' of undefined");
     });
 
-    it("rebases single-quoted URIs", function () {
-        var input = "body{background:url('fail')}";
-        var output = rebaseCss(input, fileMock, {});
-        expect(output).toBe("body{background:url(pass)}");
-    });
-
-    it("rebases double-quoted URIs", function () {
-        var input = "body{background:url(\"fail\")}";
-        var output = rebaseCss(input, fileMock, {});
-        expect(output).toBe("body{background:url(pass)}");
-    });
-
     it("rebases unquoted URIs", function () {
         var input = "body{background: url(fail)}";
         var output = rebaseCss(input, fileMock, {});


### PR DESCRIPTION
Fix invalid ES5 code generation when minifying a setter with a useless argument.
Update dependencies to more recent versions (more recent than 2 years old...).