### PR TITLE
Fix a regression related to 8cdfd39bdaae7d070e7d9ebcf8186307f8d97cb4

### DIFF
--- a/optimize.js
+++ b/optimize.js
@@ -61,7 +61,7 @@ function optimize(location, config) {
     var fs = config.fs || require("q-io/fs");
     function read(location) {
         var path = Location.toPath(location);
-        return readFile(path);
+        return readFile(path, "utf8");
     }
 
     return build(location, {


### PR DESCRIPTION
Does not load “already bundled files” anymore.