### PR TITLE
Fix missing css bug and add warning

### DIFF
--- a/lib/transform/html.js
+++ b/lib/transform/html.js
@@ -60,49 +60,56 @@ function transformDocument(file, config) {
 
     visit(file.document, function (element) {
         if (element.nodeType === Node.ELEMENT_NODE) {
-            rebaseAttribute(element, "href", file, config);
-            rebaseAttribute(element, "src", file, config);
             switch (element.tagName) {
-                case "HTML":
-                    if (appPackage.packageDescription.appcache) {
-                        var relativeLocation = URL.relative(file.buildLocation, appcacheLocation);
-                        element.setAttribute("manifest", relativeLocation);
-                    }
-                    break;
-                case "STYLE":
-                    rebaseStyleTag(element, file, config);
-                    break;
-                case "SCRIPT":
-                    rebaseScriptTag(element, file, config);
-                    break;
-                case "LINK":
-                    if (config.cssEmbedding && element.getAttribute("rel") === "stylesheet") {
-                        href = element.getAttribute("href");
-                        if (href.indexOf(":") === -1) {
-                            cssFile = config.files[URL.resolve(file.location, href)];
-                            cssFile = cssFile ? cssFile.utf8 : "";
-                            styleElement = file.document.createElement("style");
-                            var appPackageRelativePath = URL.resolve(
-                                    href,
-                                    URL.relative(
-                                        appPackage.buildLocation,
-                                        file.buildLocation
-                                    )
-                                ),
-                                cssText;
+            case "HTML":
+                if (appPackage.packageDescription.appcache) {
+                    var relativeLocation = URL.relative(file.buildLocation, appcacheLocation);
+                    element.setAttribute("manifest", relativeLocation);
+                }
+                break;
+            case "STYLE":
+                rebaseStyleTag(element, file, config);
+                break;
+            case "SCRIPT":
+                rebaseAttribute(element, "src", file, config);
+                rebaseScriptTag(element, file, config);
+                break;
+            case "LINK":
+                if (config.cssEmbedding && element.getAttribute("rel") === "stylesheet") {
+                    href = element.getAttribute("href");
+                    if (href.indexOf(":") === -1) {
+                        cssFile = config.files[URL.resolve(file.location, href)];
+                        if (cssFile === undefined) {
+                            config.out.warn("Stylesheet file not found: " + URL.resolve(file.location, href));
+                        }
+                        cssFile = cssFile ? cssFile.utf8 : "";
+                        styleElement = file.document.createElement("style");
+                        rebaseAttribute(element, "href", file, config);
+                        var appPackageRelativePath = URL.resolve(
+                                element.getAttribute("href"),
+                                URL.relative(
+                                    appPackage.buildLocation,
+                                    file.buildLocation
+                                )
+                            ),
+                            cssText;
 
-                            cssText = transformCss.resolve(appPackageRelativePath, cssFile, config).trim();
-                            if (cssText.length) {
-                                styleElement.appendChild(
-                                    file.document.createTextNode(cssText)
-                                );
-                                element.parentNode.replaceChild(styleElement, element);
-                            } else {
-                                element.parentNode.removeChild(element);
-                            }
+                        cssText = transformCss.resolve(appPackageRelativePath, cssFile, config).trim();
+                        if (cssText.length) {
+                            styleElement.appendChild(
+                                file.document.createTextNode(cssText)
+                            );
+                            element.parentNode.replaceChild(styleElement, element);
+                        } else {
+                            element.parentNode.removeChild(element);
                         }
                     }
-                    break;
+                }
+                break;
+            default:
+                rebaseAttribute(element, "href", file, config);
+                rebaseAttribute(element, "src", file, config);
+                break;
             }
         }
     });


### PR DESCRIPTION
Fixes a bug happening when trying to embed a file from a link rel
stylesheet tag. If the href path had node_modules on it, the file could
not be found because of the bug, it was not embedded and the link tag
ended being removed.

Unrelated to the bug or bug fix, this commit also adds a warning for
missing stylesheet files that are not found/existent.