### PR TITLE
make sure mop binary display error and return exitCode 1 on failure

### DIFF
--- a/optimize.js
+++ b/optimize.js
@@ -113,6 +113,8 @@ function version() {
 }
 
 function main() {
+
+
     var Options = require("optimist");
 
     var argv = Options
@@ -153,13 +155,23 @@ function main() {
     // convert path to locations
     location = Path.resolve(process.cwd(), location);
 
-    optimize(location, {
+    // Exit code
+    var exitCode = 0;
+    
+    return optimize(location, {
         buildLocation: argv.t || argv.target,
         minify: argv.optimize > 0,
         lint: argv.l || argv.lint,
         noCss: !argv.css,
         cssEmbedding: argv["css-embedding"],
         delimiter: argv.delimiter
+    }).then(function () {
+        console.log("Optimization done.");
+    }).catch(function (err) {
+        console.error('Optimization Failed: ', err.message, err.stack);
+        exitCode = 1;
+    }).then(function () {
+        process.exit(exitCode);
     });
 }
 


### PR DESCRIPTION
Example result:
<img width="1299" alt="screen shot 2017-11-16 at 2 43 45 pm" src="https://user-images.githubusercontent.com/8635/32920015-9b6b721e-cadc-11e7-89c8-6bc02a29cafe.png">

Will only impact cli use via main not custom export.optimize usage.