### PR TITLE
Improve flexibility with github dependencies

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -15,7 +15,7 @@ var path = require("path");
 
 module.exports = read;
 function read(location, config) {
-    
+
     return MontageBootstrap.loadPackage(location, config)
     .then(function (package) {
         return loadDeepPackages(package)
@@ -35,34 +35,53 @@ function read(location, config) {
     });
 }
 
+// Detecting whether a package is a GitHub package can be tricky since npm accepts
+// multiple different formats for GitHub urls. All the following predicates are valid:
+// - montagejs/montage
+// - git@github.com:montagejs/montage
+// - github.com:montagejs/montage
+// - git+ssh://git@github.com:npm/npm.git#v1.0.27
+// - git+ssh://git@github.com:npm/npm#semver:^5.0
+// - git+https://isaacs@github.com/npm/npm.git
+// - git://github.com/npm/npm.git#v1.0.27
+// While some kinds of predicates should absolutely not be treated as GitHub
+// dependencies:
+// - ^17.0.6
+// - file:../my-local-dependency
+var githubSshPredicateRegex = /^((git(\+ssh)?:\/\/)?(\w*@?)github(.com)?:)?\w*\/\w*/;
+var githubHttpsPredicateRegex = /^((git(\+https)?:\/\/)?(\w*@?)github.com\/)?\w*\/\w*/;
+
 function verifyVersions(package) {
-    return new Promise(function (resolve, reject) {
-           
-        if (package.hasPackage({name: "montage"})) {
-            var montage = package.getPackage({name: "montage"});
-            var montagePredicate = mopDescription.dependencies.montage;
-            if (!semver.satisfies(montage.packageDescription.version, montagePredicate)) {
-                reject(new Error(
-                    "Mop only supports Montage " + montagePredicate + ".  This app has " +
-                    montage.packageDescription.version
-                ));
+    return new Promise(function (resolve) {
+        function verifyVersion(dependencyName) {
+            if (!package.hasPackage({name: dependencyName})) {
                 return;
+            }
+            var dependency = package.getPackage({name: dependencyName});
+            var predicate = mopDescription.dependencies[dependencyName];
+            var isPredicateGithub = githubSshPredicateRegex.test(predicate) || githubHttpsPredicateRegex.test(predicate);
+            if (isPredicateGithub && !dependency.packageDescription._from) {
+                console.warn("Mop only supports " + dependencyName + " " + predicate +
+                    ". This app appears to have a copy that was not installed through npm."
+                );
+                console.warn("Compilation will continue, but compatibility cannot be guaranteed. " +
+                    "Proceed at your own risk."
+                );
+            } else if (
+                isPredicateGithub ?
+                    dependency.packageDescription._from !== predicate :
+                        !semver.satisfies(dependency.packageDescription.version, predicate)
+            ) {
+                throw new Error(
+                    "Mop only supports " + dependencyName + " " + predicate +
+                    ". This app has " + dependency.packageDescription.version
+                );
             }
         }
 
-        if (package.hasPackage({name: "mr"})) {
-            var mr = package.getPackage({name: "mr"});
-            var mrPredicate = mopDescription.dependencies.mr;
-            if (!semver.satisfies(mr.packageDescription.version, mrPredicate)) {
-                reject(new Error(
-                    "Mop only supports Montage Require (mr) " + mrPredicate + ".  This app has " +
-                    mr.packageDescription.version
-                ));
-                return;
-            }
-        } 
-
-        return resolve(package);
+        verifyVersion("montage");
+        verifyVersion("mr");
+        resolve(package);
     });
 }
 


### PR DESCRIPTION
Currently mop only handles version checking if the dependency predicate starts with `github.com:`, but there are plenty of other valid github URL formats, this PR adds them all.

Also currently mop is inconvenient when working with a manually cloned copy of mr and/or montage. You have to manually add a `_from` attribute in the dependency's package.json in order to make mop happy. This PR changes mop to just output a warning if it sees a dependency that is supposed to be installed through npm+github but doesn't have a `_from` attribute.