### PR TITLE
Disable MJSON compilation

### DIFF
--- a/lib/bundle/montage.js
+++ b/lib/bundle/montage.js
@@ -1,8 +1,13 @@
 
 var Bundle = require("../bundle");
-var MontageBootstrap = require("montage/montage");
+var MrBootstrap = require("mr/bootstrap-node");
 var URL = require("url2");
 var Promise = require("bluebird");
+
+// We need to load montage's bootstrap to get the loaders/compilers it configures
+// We then disable the mjson compiler, as it executes constructor functions that
+// might not work in node
+require("montage/montage").compileMJSONFile = undefined;
 
 module.exports = bundleMontageHtml;
 // returns new script location
@@ -71,7 +76,7 @@ function loadMontageScript(element, file, config) {
     // loaded at each stage of bundling
     var applicationLocation = file.package.location;
     var montageLocation = file.package.getPackage({name: "montage"}).location;
-    return MontageBootstrap.loadPackage(applicationLocation, config)
+    return MrBootstrap.loadPackage(applicationLocation, config)
     .then(function (applicationPackage) {
         return applicationPackage.loadPackage(montageLocation)
         .then(function (montagePackage) {

--- a/lib/read.js
+++ b/lib/read.js
@@ -1,4 +1,4 @@
-var MontageBootstrap = require("montage/montage");
+var MrBootstrap = require("mr/bootstrap-node");
 var Promise = require("bluebird");
 var URL = require("url2");
 var semver = require("semver");
@@ -18,8 +18,7 @@ var keys = require('object-keys');
 
 module.exports = read;
 function read(location, config) {
-
-    return MontageBootstrap.loadPackage(location, config)
+    return MrBootstrap.loadPackage(location, config)
     .then(function (appPackage) {
         return loadDeepPackages(appPackage)
         .then(function (package) {


### PR DESCRIPTION
A post-17.1.2 commit adds mjson serialization to montage, so that we can do require(“foo.mjson”) and get the instantiated object back instead of the json content.
`mop` has to use montage to load packages in order to have things like the template compiler
but in doing so, it sets up the mjson compiler, which will be run when mop picks up .mjson files
those .mjson files are compiled and executed, leading to code in the constructor of logic modules being executed. This basically means that `mop` will NOT work on an app that isn’t isomorphic.