### PR TITLE
Disable mjson compiler

### DIFF
--- a/lib/bundle/montage.js
+++ b/lib/bundle/montage.js
@@ -3,6 +3,13 @@ var Bundle = require("../bundle");
 var MontageBootstrap = require("montage/montage");
 var URL = require("url2");
 var Promise = require("bluebird");
+var Require = require("mr");
+
+// Disable the mjson compiler, as it executes constructor functions that
+// might not work in node
+if (Require.delegate && Require.delegate.compileMJSONFile) {
+    Require.delegate.compileMJSONFile = undefined;
+}
 
 module.exports = bundleMontageHtml;
 // returns new script location

--- a/lib/bundle/montage.js
+++ b/lib/bundle/montage.js
@@ -7,6 +7,13 @@ var Require = require("mr");
 
 // Disable the mjson compiler, as it executes constructor functions that
 // might not work in node
+// TODO: The real problem here is that montage instantiates serialization
+// objects when they are loaded instead of when they are required. When that is
+// fixed, these lines will be unnecessary.
+// This does not cause any problems for mop, as it discovers MJSON dependencies
+// not through compileMJSONFile but through the TemplateLoader added by
+// montage/node.js.
+// See https://github.com/montagejs/montage/issues/2008
 if (Require.delegate && Require.delegate.compileMJSONFile) {
     Require.delegate.compileMJSONFile = undefined;
 }


### PR DESCRIPTION
A post-17.1.2 commit adds mjson serialization to montage, so that we can do require(“foo.mjson”) and get the instantiated object back instead of the json content.
mop has to use montage to load packages in order to have things like the template compiler
but in doing so, it sets up the mjson compiler, which will be run when mop picks up .mjson files.
Those .mjson files are compiled and executed, leading to code in the constructor of logic modules being executed. This basically means that mop will NOT work on an app that isn’t isomorphic.

An example is a montage app with a `montage-data.mjson` that eventually loads a service with some logic involving the window or document in its constructor. Since the service will be instantiated by loading the app package, and mop runs under node, the build will error out.